### PR TITLE
Integrate EmplyeeId

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -22,6 +22,8 @@ public class Messages {
     public static final String MESSAGE_SUCCESS = "New anniversary added: %1$s";
     public static final String MESSAGE_PERSON_NOT_FOUND = "No person found with employeeId = %s";
     public static final String MESSAGE_PERSON_PREFIX_NOT_FOUND = "No person found with employeeId starting with %s";
+    public static final String MESSAGE_MULTIPLE_EMPLOYEES_FOUND_WITH_PREFIX =
+            "Found multiple employees with employeeId starting with %s";
     public static final String MESSAGE_DUPLICATE_ANNIVERSARY =
             "This exact anniversary (date + name + type + description) already exists for that person.";
     public static final String MESSAGE_ANNIVERSARY_OUT_OF_BOUNDS =

--- a/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
@@ -44,7 +44,7 @@ public class AddPersonCommand extends Command {
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
     public static final String MESSAGE_EMPLOYEE_ID_CONFLICT = "This employee ID is either a prefix of another "
-            + "added employee ID or another added employee ID is a prefix of this one";
+            + "existing employee ID or another existing employee ID is a prefix of this one";
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
@@ -43,6 +43,8 @@ public class AddPersonCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_EMPLOYEE_ID_CONFLICT = "This employee ID is either a prefix of another "
+            + "added employee ID or another added employee ID is a prefix of this one";
 
     private final Person toAdd;
 
@@ -63,6 +65,10 @@ public class AddPersonCommand extends Command {
 
         if (model.hasPerson(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
+        if (model.hasEmployeeIdPrefixConflict(toAdd.getEmployeeId())) {
+            throw new CommandException(MESSAGE_EMPLOYEE_ID_CONFLICT);
         }
 
         model.addPerson(toAdd);

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -14,7 +14,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 
 import lombok.Data;
 import seedu.address.commons.util.CollectionUtil;
@@ -24,6 +23,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -114,7 +114,7 @@ public class EditCommand extends Command {
          * this is purposefully kept as personToEdit.getEmployeeId(), currently changing EmployeeID is not supported,
          * under Roman to change as he suggests.
          */
-        UUID employeeId = personToEdit.getEmployeeId();
+        EmployeeId employeeId = personToEdit.getEmployeeId();
         Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
@@ -164,7 +164,7 @@ public class EditCommand extends Command {
      */
     @Data
     public static class EditPersonDescriptor {
-        private UUID employeeId;
+        private EmployeeId employeeId;
         private Name name;
         private Phone phone;
         private Email email;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -97,7 +97,8 @@ public class EditCommand extends Command {
 
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        if (model.hasEmployeeIdPrefixConflictIgnoringSpecific(editedPerson.getEmployeeId(), personToEdit.getEmployeeId())) {
+        if (model.hasEmployeeIdPrefixConflictIgnoringSpecific(editedPerson.getEmployeeId(),
+                personToEdit.getEmployeeId())) {
             throw new CommandException(MESSAGE_EMPLOYEE_ID_CONFLICT);
         }
 

--- a/src/main/java/seedu/address/logic/commands/anniversary/AddAnniversaryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/anniversary/AddAnniversaryCommand.java
@@ -4,7 +4,6 @@ package seedu.address.logic.commands.anniversary;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_DUPLICATE_ANNIVERSARY;
-import static seedu.address.logic.Messages.MESSAGE_PERSON_NOT_FOUND;
 import static seedu.address.logic.Messages.MESSAGE_SUCCESS;
 
 import java.util.ArrayList;

--- a/src/main/java/seedu/address/logic/commands/anniversary/AddAnniversaryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/anniversary/AddAnniversaryCommand.java
@@ -10,11 +10,13 @@ import static seedu.address.logic.Messages.MESSAGE_SUCCESS;
 import java.util.ArrayList;
 import java.util.List;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.anniversary.Anniversary;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Person;
 
 /**
@@ -24,10 +26,10 @@ public class AddAnniversaryCommand extends Command {
 
     public static final String COMMAND_WORD = "anniversary";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an anniversary to the person with the "
-            + "specified employee ID.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an anniversary to the person identified by "
+            + "a prefix of their Employee ID.\n"
             + "Parameters: "
-            + "eid/EMPLOYEE_ID "
+            + "eid/EMPLOYEE_ID_PREFIX "
             + "d/DATE "
             + "n/ANNIVERSARY_NAME "
             + "[ad/DESCRIPTION] "
@@ -40,31 +42,38 @@ public class AddAnniversaryCommand extends Command {
             + "at/Personal "
             + "at/Family";
     private final Anniversary toAdd;
-    private final String employeeIdToFind;
+    private final EmployeeId employeeIdPrefix;
 
     /**
      * Creates an AddAnniversaryCommand to add the specified {@code Anniversary} to the person with given employeeId.
      */
-    public AddAnniversaryCommand(String employeeId, Anniversary anniversary) {
-        requireNonNull(employeeId);
+    public AddAnniversaryCommand(EmployeeId employeeIdPrefix, Anniversary anniversary) {
+        requireNonNull(employeeIdPrefix);
         requireNonNull(anniversary);
-        this.employeeIdToFind = employeeId;
+        this.employeeIdPrefix = employeeIdPrefix;
         this.toAdd = anniversary;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        List<Person> matchedEmployees = model.getFilteredByEmployeeIdPrefixList(employeeIdPrefix);
 
-        // Attempt to find the person in model by employeeId
-        Person personToEdit = model.getFilteredPersonList().stream()
-                .filter(p -> p.getEmployeeId().toString().equals(employeeIdToFind))
-                .findFirst()
-                .orElse(null);
-
-        if (personToEdit == null) {
-            throw new CommandException(String.format(MESSAGE_PERSON_NOT_FOUND, employeeIdToFind));
+        if (matchedEmployees.size() > 1) {
+            throw new CommandException(String.format(
+                    Messages.MESSAGE_MULTIPLE_EMPLOYEES_FOUND_WITH_PREFIX,
+                    employeeIdPrefix
+            ));
         }
+
+        if (matchedEmployees.isEmpty()) {
+            throw new CommandException(String.format(
+                    Messages.MESSAGE_PERSON_PREFIX_NOT_FOUND,
+                    employeeIdPrefix
+            ));
+        }
+
+        Person personToEdit = matchedEmployees.get(0);
 
         // Check if the same anniversary already exists
         boolean duplicate = personToEdit.getAnniversaries().stream()

--- a/src/main/java/seedu/address/logic/commands/anniversary/DeleteAnniversaryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/anniversary/DeleteAnniversaryCommand.java
@@ -2,8 +2,6 @@ package seedu.address.logic.commands.anniversary;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_ANNIVERSARY_OUT_OF_BOUNDS;
-import static seedu.address.logic.Messages.MESSAGE_PERSON_NOT_FOUND;
-import static seedu.address.logic.commands.anniversary.AddAnniversaryCommand.COMMAND_WORD;
 
 import java.util.List;
 

--- a/src/main/java/seedu/address/logic/commands/anniversary/DeleteAnniversaryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/anniversary/DeleteAnniversaryCommand.java
@@ -8,11 +8,13 @@ import static seedu.address.logic.commands.anniversary.AddAnniversaryCommand.COM
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.anniversary.Anniversary;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Person;
 
 /**
@@ -21,33 +23,46 @@ import seedu.address.model.person.Person;
 public class DeleteAnniversaryCommand extends Command {
     public static final String MESSAGE_SUCCESS = "anniversary added: %1$s";
     public static final String COMMAND_WORD = "deleteAnniversary";
-    public static final Object MESSAGE_USAGE = COMMAND_WORD + ": deletes an anniversary to the person with the "
-            + "specified employee ID.\n"
+    public static final Object MESSAGE_USAGE = COMMAND_WORD + ": deletes an anniversary to the person identified by a "
+            + "prefix of their Employee ID.\n"
             + "Parameters: "
             + "eid/EMPLOYEE_ID "
             + "ad/index ";
     private final Index targetIndex;
-    private final String employeeIdToFind;
+    private final EmployeeId employeeIdPrefix;
 
     /**
      * constructs a deleteAnniversaryCommand
      * @param targetIndex tar
-     * @param employeeIdToFind emp
+     * @param employeeIdPrefix emp
      */
-    public DeleteAnniversaryCommand(Index targetIndex, String employeeIdToFind) {
+    public DeleteAnniversaryCommand(Index targetIndex, EmployeeId employeeIdPrefix) {
         this.targetIndex = targetIndex;
-        this.employeeIdToFind = employeeIdToFind;
+        this.employeeIdPrefix = employeeIdPrefix;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        // Attempt to find the person in model by employeeId
-        Person personToEdit = model.getFilteredPersonList().stream()
-                .filter(p -> p.getEmployeeId().toString().equals(employeeIdToFind))
-                .findFirst()
-                .orElseThrow(()->new CommandException(MESSAGE_PERSON_NOT_FOUND));
+        List<Person> matchedEmployees = model.getFilteredByEmployeeIdPrefixList(employeeIdPrefix);
+
+        if (matchedEmployees.size() > 1) {
+            throw new CommandException(String.format(
+                    Messages.MESSAGE_MULTIPLE_EMPLOYEES_FOUND_WITH_PREFIX,
+                    employeeIdPrefix
+            ));
+        }
+
+        if (matchedEmployees.isEmpty()) {
+            throw new CommandException(String.format(
+                    Messages.MESSAGE_PERSON_PREFIX_NOT_FOUND,
+                    employeeIdPrefix
+            ));
+        }
+
+        Person personToEdit = matchedEmployees.get(0);
         List<Anniversary> anniversaryList = personToEdit.getAnniversaries();
+
 
         if (targetIndex.getZeroBased() >= anniversaryList.size()) {
             throw new CommandException(MESSAGE_ANNIVERSARY_OUT_OF_BOUNDS);

--- a/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
@@ -12,8 +12,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_WORK_ANNIVERSARY;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddPersonCommand;
@@ -21,6 +21,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.anniversary.Anniversary;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -48,8 +49,14 @@ public class AddPersonCommandParser implements Parser<AddPersonCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_EMPLOYEEID, PREFIX_NAME,
                 PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
-        UUID employeeId = ParserUtil.parseEmployeeId(argMultimap.getValue(PREFIX_EMPLOYEEID)
-                .orElse(UUID.randomUUID().toString()));
+
+        Optional<String> employeeIdString = argMultimap.getValue(PREFIX_EMPLOYEEID);
+        EmployeeId employeeId;
+        if (employeeIdString.isPresent()) {
+            employeeId = ParserUtil.parseEmployeeId(employeeIdString.get());
+        } else {
+            employeeId = EmployeeId.generateNewEmployeeId();
+        }
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -25,5 +25,4 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
         }
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.EmployeeId;

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.EmployeeId;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -18,8 +19,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            EmployeeId employeeIdPrefix = ParserUtil.parseEmployeeIdPrefix(args);
+            return new DeleteCommand(employeeIdPrefix);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -47,8 +47,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         try {
             employeeIdPrefix = ParserUtil.parseEmployeeIdPrefix(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage())
-                    + '\n' + EditCommand.MESSAGE_USAGE, pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMPLOYEEID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -31,7 +32,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_EMPLOYEEID, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
         String employeeIdPrefix;
 
@@ -41,10 +42,13 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_EMPLOYEEID, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
+        if (argMultimap.getValue(PREFIX_EMPLOYEEID).isPresent()) {
+            editPersonDescriptor.setEmployeeId(ParserUtil.parseEmployeeId(argMultimap.getValue(PREFIX_EMPLOYEEID).get()));
+        }
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -32,23 +32,39 @@ public class EditCommandParser implements Parser<EditCommand> {
      */
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_EMPLOYEEID, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
+                args,
+                PREFIX_EMPLOYEEID,
+                PREFIX_NAME,
+                PREFIX_PHONE,
+                PREFIX_EMAIL,
+                PREFIX_ADDRESS,
+                PREFIX_TAG
+        );
 
         EmployeeId employeeIdPrefix;
 
         try {
             employeeIdPrefix = ParserUtil.parseEmployeeIdPrefix(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage()) + '\n' + EditCommand.MESSAGE_USAGE, pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage())
+                    + '\n' + EditCommand.MESSAGE_USAGE, pe);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_EMPLOYEEID, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
+        argMultimap.verifyNoDuplicatePrefixesFor(
+                PREFIX_EMPLOYEEID,
+                PREFIX_NAME,
+                PREFIX_PHONE,
+                PREFIX_EMAIL,
+                PREFIX_ADDRESS
+        );
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
         if (argMultimap.getValue(PREFIX_EMPLOYEEID).isPresent()) {
-            editPersonDescriptor.setEmployeeId(ParserUtil.parseEmployeeId(argMultimap.getValue(PREFIX_EMPLOYEEID).get()));
+            editPersonDescriptor.setEmployeeId(ParserUtil.parseEmployeeId(
+                    argMultimap.getValue(PREFIX_EMPLOYEEID).get()
+            ));
         }
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -34,12 +35,12 @@ public class EditCommandParser implements Parser<EditCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_EMPLOYEEID, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
-        String employeeIdPrefix;
+        EmployeeId employeeIdPrefix;
 
         try {
             employeeIdPrefix = ParserUtil.parseEmployeeIdPrefix(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage()) + '\n' + EditCommand.MESSAGE_USAGE, pe);
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_EMPLOYEEID, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -28,9 +28,8 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-    public static final String MALFORMED_INVALID_EMPLOYEE_ID = "Invalid employee id! %s";
     public static final String MESSAGE_EMPLOYEE_ID_PREFIX_NOT_SPECIFIED = "Employee id prefix not specified!";
-    public static final String MESSAGE_SPACES_IN_EMPLOYEE_ID = "Employee id can't start contain spaces!";
+    public static final String MESSAGE_EMPLOYEE_ID_PREFIX_FORMAT = "Employee id can't start contain spaces!";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -57,7 +56,7 @@ public class ParserUtil {
         if (!EmployeeId.isValidEmployeeId(trimmedEmployeeId)) {
             throw new ParseException(EmployeeId.MESSAGE_CONSTRAINTS);
         }
-        return new EmployeeId(trimmedEmployeeId);
+        return EmployeeId.fromString(trimmedEmployeeId);
     }
 
     /**
@@ -65,15 +64,16 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code employeeIdPrefix} is empty or contains spaces.
      */
-    public static String parseEmployeeIdPrefix(String employeeIdPrefix) throws ParseException {
+    public static EmployeeId parseEmployeeIdPrefix(String employeeIdPrefix) throws ParseException {
         requireNonNull(employeeIdPrefix);
         if (employeeIdPrefix.isEmpty()) {
             throw new ParseException(MESSAGE_EMPLOYEE_ID_PREFIX_NOT_SPECIFIED);
         }
-        if (employeeIdPrefix.contains(" ")) {
-            throw new ParseException(MESSAGE_SPACES_IN_EMPLOYEE_ID);
+        employeeIdPrefix = employeeIdPrefix.trim();
+        if (!EmployeeId.isValidEmployeeId(employeeIdPrefix)) {
+            throw new ParseException(EmployeeId.MESSAGE_PREFIX_CONSTRAINTS);
         }
-        return employeeIdPrefix.trim();
+        return EmployeeId.fromString(employeeIdPrefix);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -7,7 +7,6 @@ import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
@@ -18,6 +17,7 @@ import seedu.address.model.anniversary.Birthday;
 import seedu.address.model.anniversary.WorkAnniversary;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -51,14 +51,13 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code name} is invalid.
      */
-    public static UUID parseEmployeeId(String employeeId) throws ParseException {
+    public static EmployeeId parseEmployeeId(String employeeId) throws ParseException {
         requireNonNull(employeeId);
         String trimmedEmployeeId = employeeId.trim();
-        try {
-            return UUID.fromString(trimmedEmployeeId);
-        } catch (IllegalArgumentException e) {
-            throw new ParseException(String.format(MALFORMED_INVALID_EMPLOYEE_ID, trimmedEmployeeId));
+        if (!EmployeeId.isValidEmployeeId(trimmedEmployeeId)) {
+            throw new ParseException(EmployeeId.MESSAGE_CONSTRAINTS);
         }
+        return new EmployeeId(trimmedEmployeeId);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/anniversary/AddAnniversaryCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/anniversary/AddAnniversaryCommandParser.java
@@ -17,9 +17,11 @@ import seedu.address.logic.commands.anniversary.AddAnniversaryCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.anniversary.Anniversary;
 import seedu.address.model.anniversary.AnniversaryType;
+import seedu.address.model.person.EmployeeId;
 
 /**
  * Parses input arguments and creates a new AddAnniversaryCommand object
@@ -44,7 +46,7 @@ public class AddAnniversaryCommandParser implements Parser<AddAnniversaryCommand
         }
 
         // parse required fields
-        String employeeId = argMultimap.getValue(PREFIX_EMPLOYEEID).get();
+        EmployeeId employeeIdPrefix = ParserUtil.parseEmployeeIdPrefix(argMultimap.getValue(PREFIX_EMPLOYEEID).get());
         String dateStr = argMultimap.getValue(PREFIX_ANNIVERSARY_DATE).get();
         String nameStr = argMultimap.getValue(PREFIX_NAME).get();
 
@@ -75,6 +77,6 @@ public class AddAnniversaryCommandParser implements Parser<AddAnniversaryCommand
                 nameStr
         );
 
-        return new AddAnniversaryCommand(employeeId, newAnniversary);
+        return new AddAnniversaryCommand(employeeIdPrefix, newAnniversary);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/anniversary/DeleteAnniversaryCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/anniversary/DeleteAnniversaryCommandParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.EmployeeId;
 
 /**
  * parses a deleteAnniversaryCommand
@@ -38,9 +39,11 @@ public class DeleteAnniversaryCommandParser implements Parser<DeleteAnniversaryC
             );
         }
         try {
-            String employeeId = argMultimap.getValue(PREFIX_EMPLOYEEID).get();
+            EmployeeId employeeIdPrefix = ParserUtil.parseEmployeeIdPrefix(
+                    argMultimap.getValue(PREFIX_EMPLOYEEID).get()
+            );
             Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_ANNIVERSARY_DATE).get());
-            return new DeleteAnniversaryCommand(index, employeeId);
+            return new DeleteAnniversaryCommand(index, employeeIdPrefix);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -83,6 +83,10 @@ public class AddressBook implements ReadOnlyAddressBook {
         return persons.hasDuplicatePersonDetails(person);
     }
 
+    /**
+     * Checks whether the given {@code EmployeeId} has a prefix conflict with any existing employee ID
+     * in the address book. A prefix conflict occurs when one employee ID is a prefix of another.
+     */
     public boolean hasEmployeeIdPrefixConflict(EmployeeId employeeId) {
         requireNonNull(employeeId);
         return persons.hasEmployeeIdPrefixConflict(employeeId);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -85,11 +85,25 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     /**
      * Checks whether the given {@code EmployeeId} has a prefix conflict with any existing employee ID
-     * in the address book. A prefix conflict occurs when one employee ID is a prefix of another.
+     * in the address book. A prefix conflict occurs when one employee ID is a prefix of another one.
      */
     public boolean hasEmployeeIdPrefixConflict(EmployeeId employeeId) {
         requireNonNull(employeeId);
         return persons.hasEmployeeIdPrefixConflict(employeeId);
+    }
+
+    /**
+     * Checks if there is an employee ID in the address book that has a prefix conflict
+     * with the given employee ID, while ignoring a specific employee ID.
+     * A prefix conflict occurs when one employee ID is a prefix of another employee ID.
+     *
+     * @param employeeId the employee ID to check for conflicts.
+     * @param toIgnore the employee ID to be ignored during the conflict check.
+     * @return true if a prefix conflict is found, excluding the specified employee ID to ignore; false otherwise.
+     */
+    public boolean hasEmployeeIdPrefixConflictIgnoringSpecific(EmployeeId employeeId, EmployeeId toIgnore) {
+        requireNonNull(employeeId);
+        return persons.hasEmployeeIdPrefixConflictIgnoringSpecific(employeeId, toIgnore);
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -80,6 +81,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     public boolean hasDuplicatePersonDetails(Person person) {
         requireNonNull(person);
         return persons.hasDuplicatePersonDetails(person);
+    }
+
+    public boolean hasEmployeeIdPrefixConflict(EmployeeId employeeId) {
+        requireNonNull(employeeId);
+        return persons.hasEmployeeIdPrefixConflict(employeeId);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Person;
 
 /**
@@ -65,6 +66,12 @@ public interface Model {
      * The person must exist in the address book.
      */
     void deletePerson(Person target);
+
+    /**
+     * Returns true if the given employeeId has a prefix conflict with any existing employeeId in the address book.
+     * Prefix conflict is defined as having the same prefix as another employeeId in the address book.
+     */
+    boolean hasEmployeeIdPrefixConflict(EmployeeId employeeId);
 
     /**
      * Adds the given person.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -74,6 +74,17 @@ public interface Model {
     boolean hasEmployeeIdPrefixConflict(EmployeeId employeeId);
 
     /**
+     * Checks if the given employee ID has a prefix conflict with any existing employee ID in the address book,
+     * excluding the specified {@code toIgnore} employee ID.
+     * A prefix conflict occurs when one employee ID is a prefix of another.
+     *
+     * @param employeeId The employee ID to check for prefix conflict.
+     * @param toIgnore The employee ID to ignore while checking for prefix conflicts.
+     * @return True if a prefix conflict exists, excluding the specified {@code toIgnore} employee ID; false otherwise.
+     */
+    boolean hasEmployeeIdPrefixConflictIgnoringSpecific(EmployeeId employeeId, EmployeeId toIgnore);
+
+    /**
      * Adds the given person.
      * {@code person} must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -100,6 +100,8 @@ public interface Model {
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 
+    ObservableList<Person> getFilteredByEmployeeIdPrefixList(EmployeeId employeeIdPrefix);
+
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -100,6 +100,10 @@ public interface Model {
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 
+    /**
+     * Returns an unmodifiable view of the filtered person list that contains only employees with id starting with
+     * the provided one
+     */
     ObservableList<Person> getFilteredByEmployeeIdPrefixList(EmployeeId employeeIdPrefix);
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -114,6 +114,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasEmployeeIdPrefixConflictIgnoringSpecific(EmployeeId employeeId, EmployeeId toIgnore) {
+        requireAllNonNull(employeeId, toIgnore);
+        return addressBook.hasEmployeeIdPrefixConflictIgnoringSpecific(employeeId, toIgnore);
+    }
+
+    @Override
     public boolean hasDuplicatePersonDetails(Person person) {
         requireNonNull(person);
         return addressBook.hasDuplicatePersonDetails(person);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,6 +13,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Person;
 
 /**
@@ -104,6 +105,12 @@ public class ModelManager implements Model {
     public boolean hasPerson(Person person) {
         requireNonNull(person);
         return addressBook.hasPerson(person);
+    }
+
+    @Override
+    public boolean hasEmployeeIdPrefixConflict(EmployeeId employeeId) {
+        requireNonNull(employeeId);
+        return addressBook.hasEmployeeIdPrefixConflict(employeeId);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -154,6 +154,14 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public ObservableList<Person> getFilteredByEmployeeIdPrefixList(EmployeeId employeeIdPrefix) {
+        requireNonNull(employeeIdPrefix);
+        return new FilteredList<>(
+                filteredPersons, person -> employeeIdPrefix.isPrefixOf(person.getEmployeeId())
+        );
+    }
+
+    @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);

--- a/src/main/java/seedu/address/model/person/EmployeeId.java
+++ b/src/main/java/seedu/address/model/person/EmployeeId.java
@@ -8,7 +8,7 @@ public class EmployeeId {
     public static final String MESSAGE_CONSTRAINTS =
             "Employee ID should be a string of letters and digits no longer than 36 characters.";
 
-    public static final String VALIDATION_REGEX = "[a-zA-Z0-9]{1,36}";
+    public static final String VALIDATION_REGEX = "[a-zA-Z0-9-]{1,36}";
 
     public final String value;
 
@@ -44,7 +44,7 @@ public class EmployeeId {
 
     /**
      * Returns true if the employee ID has a prefix conflict with another employee ID.
-     * A prefix conflict occurs when one employee ID is a prefix of another.
+     * A prefix conflict occurs when one employee ID is a prefix of another one.
      */
     public boolean hasPrefixConflict(EmployeeId other) {
         return this.value.startsWith(other.value) || other.value.startsWith(this.value);

--- a/src/main/java/seedu/address/model/person/EmployeeId.java
+++ b/src/main/java/seedu/address/model/person/EmployeeId.java
@@ -1,0 +1,63 @@
+package seedu.address.model.person;
+
+/**
+ * Represents a Person's employee ID in the address book.
+ */
+public class EmployeeId {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Employee ID should be a string of letters and digits no longer than 36 characters.";
+
+    public static final String VALIDATION_REGEX = "[a-zA-Z0-9]{1,36}";
+
+    public final String value;
+
+    /**
+     * Constructs an {@code EmployeeId}.
+     *
+     * @param employeeId A valid employee ID.
+     */
+    public EmployeeId(String employeeId) {
+        this.value = employeeId;
+    }
+
+    /**
+     * Generates an employee ID from a String
+     */
+    public static EmployeeId fromString(String employeeId) {
+        return new EmployeeId(employeeId);
+    }
+
+    /**
+     * Generates a new employee ID as a random UUID.
+     */
+    public static EmployeeId generateNewEmployeeId() {
+        return new EmployeeId(java.util.UUID.randomUUID().toString());
+    }
+
+    /**
+     * Returns true if a given string is a valid employee ID.
+     */
+    public static boolean isValidEmployeeId(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof EmployeeId)) {
+            return false;
+        }
+
+        EmployeeId otherEmployeeId = (EmployeeId) other;
+        return value.equals(otherEmployeeId.value);
+    }
+}

--- a/src/main/java/seedu/address/model/person/EmployeeId.java
+++ b/src/main/java/seedu/address/model/person/EmployeeId.java
@@ -42,6 +42,14 @@ public class EmployeeId {
         return test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Returns true if the employee ID has a prefix conflict with another employee ID.
+     * A prefix conflict occurs when one employee ID is a prefix of another.
+     */
+    public boolean hasPrefixConflict(EmployeeId other) {
+        return this.value.startsWith(other.value) || other.value.startsWith(this.value);
+    }
+
     @Override
     public String toString() {
         return value;

--- a/src/main/java/seedu/address/model/person/EmployeeId.java
+++ b/src/main/java/seedu/address/model/person/EmployeeId.java
@@ -6,7 +6,10 @@ package seedu.address.model.person;
 public class EmployeeId {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Employee ID should be a string of letters and digits no longer than 36 characters.";
+            "Employee ID must be 1-36 characters long, containing only letters, digits, and '-'.";
+
+    public static final String MESSAGE_PREFIX_CONSTRAINTS =
+            "Employee ID prefix must be 1-36 characters long, containing only letters, digits, and '-'.";
 
     public static final String VALIDATION_REGEX = "[a-zA-Z0-9-]{1,36}";
 
@@ -43,11 +46,21 @@ public class EmployeeId {
     }
 
     /**
+     * Checks if this EmployeeId is a prefix of another EmployeeId.
+     *
+     * @param other The EmployeeId to be checked against.
+     * @return true if this EmployeeId is a prefix of the specified EmployeeId, otherwise false.
+     */
+    public boolean isPrefixOf(EmployeeId other) {
+        return other.value.startsWith(this.value);
+    }
+
+    /**
      * Returns true if the employee ID has a prefix conflict with another employee ID.
      * A prefix conflict occurs when one employee ID is a prefix of another one.
      */
     public boolean hasPrefixConflict(EmployeeId other) {
-        return this.value.startsWith(other.value) || other.value.startsWith(this.value);
+        return this.isPrefixOf(other) || other.isPrefixOf(this);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -8,7 +8,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 
 import lombok.Builder;
 import lombok.Data;
@@ -28,7 +27,7 @@ import seedu.address.model.tag.Tag;
 public class Person {
 
     // Identity fields
-    private final UUID employeeId;
+    private final EmployeeId employeeId;
     private final Name name;
     private final Phone phone;
     private final Email email;
@@ -43,7 +42,7 @@ public class Person {
     /**
      * Every field must be present and not null.
      */
-    public Person(UUID employeeId, Name name, Phone phone, Email email, Address address, Set<Tag> tags,
+    public Person(EmployeeId employeeId, Name name, Phone phone, Email email, Address address, Set<Tag> tags,
                   List<Anniversary> anniversaries) {
         this.employeeId = employeeId;
         requireAllNonNull(name, phone, email, address, tags);
@@ -65,7 +64,7 @@ public class Person {
     }
 
     /**
-     * Returns true if both persons have the same uuid.
+     * Returns true if both persons have the same employee id.
      * This defines a clear notion of equality between two persons.
      */
     public boolean isSamePerson(Person otherPerson) {

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -204,10 +204,31 @@ public class UniquePersonList implements Iterable<Person> {
     /**
      * Checks if there is an employee ID in the list that has a prefix conflict
      * with the given employee ID. A prefix conflict occurs when one employee ID
-     * is a prefix of another.
+     * is a prefix of another one.
+     *
+     * @param employeeId the employee ID to check for conflicts.
+     *                   Must not be null.
+     * @return true if a prefix conflict is found, false otherwise.
      */
     public boolean hasEmployeeIdPrefixConflict(EmployeeId employeeId) {
         requireNonNull(employeeId);
         return internalList.stream().anyMatch(person -> person.getEmployeeId().hasPrefixConflict(employeeId));
+    }
+
+    /**
+     * Checks if there is an employee ID in the list that has a prefix conflict
+     * with the given employee ID, while ignoring a specific employee ID.
+     * A prefix conflict occurs when one employee ID is a prefix of another.
+     *
+     * @param employeeId the employee ID to check for conflicts.
+     * @param toIgnore   the employee ID to be ignored during the check.
+     * @return true if a prefix conflict is found excluding the specified employee ID to ignore, false otherwise.
+     */
+    public boolean hasEmployeeIdPrefixConflictIgnoringSpecific(EmployeeId employeeId, EmployeeId toIgnore) {
+        requireNonNull(employeeId);
+        requireNonNull(toIgnore);
+        return internalList.stream()
+                .filter(person -> !person.getEmployeeId().equals(toIgnore))
+                .anyMatch(person -> person.getEmployeeId().hasPrefixConflict(employeeId));
     }
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -200,4 +200,9 @@ public class UniquePersonList implements Iterable<Person> {
         requireNonNull(toCheck);
         return internalList.stream().anyMatch(checkPerson -> checkPerson.hasSameDetails(toCheck));
     }
+
+    public boolean hasEmployeeIdPrefixConflict(EmployeeId employeeId) {
+        requireNonNull(employeeId);
+        return internalList.stream().anyMatch(person -> person.getEmployeeId().hasPrefixConflict(employeeId));
+    }
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -201,6 +201,11 @@ public class UniquePersonList implements Iterable<Person> {
         return internalList.stream().anyMatch(checkPerson -> checkPerson.hasSameDetails(toCheck));
     }
 
+    /**
+     * Checks if there is an employee ID in the list that has a prefix conflict
+     * with the given employee ID. A prefix conflict occurs when one employee ID
+     * is a prefix of another.
+     */
     public boolean hasEmployeeIdPrefixConflict(EmployeeId employeeId) {
         requireNonNull(employeeId);
         return internalList.stream().anyMatch(person -> person.getEmployeeId().hasPrefixConflict(employeeId));

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -3,13 +3,13 @@ package seedu.address.model.util;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -21,27 +21,27 @@ import seedu.address.model.tag.Tag;
 public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
-            new Person(UUID.randomUUID(), new Name("Alex Yeoh"), new Phone("87438807"),
+            new Person(EmployeeId.generateNewEmployeeId(), new Name("Alex Yeoh"), new Phone("87438807"),
                     new Email("alexyeoh@example.com"),
                     new Address("Blk 30 Geylang Street 29, #06-40"),
                     getTagSet("friends"), new ArrayList<>()),
-            new Person(UUID.randomUUID(), new Name("Bernice Yu"), new Phone("99272758"),
+            new Person(EmployeeId.generateNewEmployeeId(), new Name("Bernice Yu"), new Phone("99272758"),
                     new Email("berniceyu@example.com"),
                     new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
                     getTagSet("colleagues", "friends"), new ArrayList<>()),
-            new Person(UUID.randomUUID(), new Name("Charlotte Oliveiro"),
+            new Person(EmployeeId.generateNewEmployeeId(), new Name("Charlotte Oliveiro"),
                     new Phone("93210283"), new Email("charlotte@example.com"),
                     new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
                     getTagSet("neighbours"), new ArrayList<>()),
-            new Person(UUID.randomUUID(), new Name("David Li"),
+            new Person(EmployeeId.generateNewEmployeeId(), new Name("David Li"),
                     new Phone("91031282"), new Email("lidavid@example.com"),
                     new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
                     getTagSet("family"), new ArrayList<>()),
-            new Person(UUID.randomUUID(), new Name("Irfan Ibrahim"),
+            new Person(EmployeeId.generateNewEmployeeId(), new Name("Irfan Ibrahim"),
                     new Phone("92492021"), new Email("irfan@example.com"),
                     new Address("Blk 47 Tampines Street 20, #17-35"),
                     getTagSet("classmates"), new ArrayList<>()),
-            new Person(UUID.randomUUID(), new Name("Roy Balakrishnan"),
+            new Person(EmployeeId.generateNewEmployeeId(), new Name("Roy Balakrishnan"),
                     new Phone("92624417"), new Email("royb@example.com"),
                     new Address("Blk 45 Aljunied Street 85, #11-31"),
                     getTagSet("colleagues"), new ArrayList<>())

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -89,13 +89,15 @@ class JsonAdaptedPerson {
         }
 
         if (employeeId == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, EmployeeId.class.getSimpleName()));
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    EmployeeId.class.getSimpleName()));
         }
         EmployeeId employeeIdObj;
         try {
             employeeIdObj = EmployeeId.fromString(employeeId);
         } catch (IllegalArgumentException e) {
-            throw new IllegalValueException(String.format(MALFORMED_FIELD_MESSAGE_FORMAT, EmployeeId.class.getSimpleName()));
+            throw new IllegalValueException(String.format(MALFORMED_FIELD_MESSAGE_FORMAT,
+                    EmployeeId.class.getSimpleName()));
         }
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -14,6 +13,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.anniversary.Anniversary;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -89,13 +89,13 @@ class JsonAdaptedPerson {
         }
 
         if (employeeId == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, UUID.class.getSimpleName()));
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, EmployeeId.class.getSimpleName()));
         }
-        UUID employeeIdObj;
+        EmployeeId employeeIdObj;
         try {
-            employeeIdObj = UUID.fromString(employeeId);
+            employeeIdObj = EmployeeId.fromString(employeeId);
         } catch (IllegalArgumentException e) {
-            throw new IllegalValueException(String.format(MALFORMED_FIELD_MESSAGE_FORMAT, UUID.class.getSimpleName()));
+            throw new IllegalValueException(String.format(MALFORMED_FIELD_MESSAGE_FORMAT, EmployeeId.class.getSimpleName()));
         }
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -1,7 +1,6 @@
 package seedu.address.ui;
 
 import java.util.List;
-import java.util.UUID;
 import java.util.logging.Logger;
 
 import javafx.event.ActionEvent;
@@ -19,6 +18,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.anniversary.Anniversary;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Person;
 
 /**
@@ -137,14 +137,14 @@ public class MainWindow extends UiPart<Stage> {
      * showAnniversaries eid//<someUUID/>
      */
     @FXML
-    public void handleShowAnniversaries(String employeeId) {
+    public void handleShowAnniversaries(String employeeIdString) {
         try {
-            // Convert employeeId string to UUID
-            UUID uuid = UUID.fromString(employeeId);
+            // Convert employeeIdString to employeeId
+            EmployeeId employeeId = EmployeeId.fromString(employeeIdString);
 
-            // Find the person by UUID
+            // Find the person by employee id
             Person selected = logic.getFilteredPersonList().stream()
-                    .filter(person -> person.getEmployeeId().equals(uuid))
+                    .filter(person -> person.getEmployeeId().equals(employeeId))
                     .findFirst()
                     .orElse(null);
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_PERSON_PREFIX_NOT_FOUND;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.logic.Messages.MESSAGE_PERSON_PREFIX_NOT_FOUND;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.BIRTHDAY_DESC_AMY;
@@ -65,7 +66,7 @@ public class LogicManagerTest {
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
         String deleteCommand = "delete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandException(deleteCommand, String.format(MESSAGE_PERSON_PREFIX_NOT_FOUND, "9"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AddPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPersonCommandTest.java
@@ -202,11 +202,6 @@ public class AddPersonCommandTest {
             requireNonNull(person);
             return this.person.isSamePerson(person);
         }
-//
-//        @Override
-//        public boolean hasEmployeeIdPrefixConflict(EmployeeId employeeId) {
-//            return this.person.getEmployeeId().hasPrefixConflict(employeeId);
-//        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPersonCommandTest.java
@@ -22,6 +22,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
 
@@ -140,6 +141,16 @@ public class AddPersonCommandTest {
         }
 
         @Override
+        public boolean hasEmployeeIdPrefixConflict(EmployeeId employeeId) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasEmployeeIdPrefixConflictIgnoringSpecific(EmployeeId employeeId, EmployeeId toIgnore) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasDuplicatePersonDetails(Person person) {
             throw new AssertionError("This method should not be called.");
         }
@@ -156,6 +167,11 @@ public class AddPersonCommandTest {
 
         @Override
         public ObservableList<Person> getFilteredPersonList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredByEmployeeIdPrefixList(EmployeeId employeeIdPrefix) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -186,6 +202,11 @@ public class AddPersonCommandTest {
             requireNonNull(person);
             return this.person.isSamePerson(person);
         }
+//
+//        @Override
+//        public boolean hasEmployeeIdPrefixConflict(EmployeeId employeeId) {
+//            return this.person.getEmployeeId().hasPrefixConflict(employeeId);
+//        }
     }
 
     /**
@@ -209,6 +230,11 @@ public class AddPersonCommandTest {
         @Override
         public ReadOnlyAddressBook getAddressBook() {
             return new AddressBook();
+        }
+
+        @Override
+        public boolean hasEmployeeIdPrefixConflict(EmployeeId employeeId) {
+            return false;
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -32,6 +32,8 @@ public class CommandTestUtil {
 
     public static final String VALID_EMPLOYEE_ID_AMY = "13f49674-72f2-47db-96dc-1c6a0110b724";
     public static final String VALID_EMPLOYEE_ID_BOB = "6f7253df-40e0-4da7-803d-4420d1ef2aeb";
+    public static final String VALID_EMPLOYEE_ID_PREFIX_AMY = "13f49674";
+    public static final String VALID_EMPLOYEE_ID_PREFIX_BOB = "6f7253df";
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_PHONE_AMY = "11111111";
@@ -65,7 +67,7 @@ public class CommandTestUtil {
     public static final String WORK_ANNIVERSARY_DESC_AMY = " " + PREFIX_WORK_ANNIVERSARY + "1995-03-16";
     public static final String WORK_ANNIVERSARY_DESC_BOB = " " + PREFIX_WORK_ANNIVERSARY + "1999-06-11";
 
-    public static final String UNEXISTING_EMPLOYEE_ID_PREFIX = "99999"; // no employee id should start with this
+    public static final String INVALID_EMPLOYEE_ID_PREFIX = "--99999--"; // no employee id should start with this
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -3,6 +3,9 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMPLOYEE_ID_PREFIX;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMPLOYEE_ID_PREFIX_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMPLOYEE_ID_PREFIX_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
@@ -17,6 +20,7 @@ import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Person;
 
 /**
@@ -30,7 +34,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteCommand = new DeleteCommand(personToDelete.getEmployeeId());
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
@@ -43,10 +47,12 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(EmployeeId.fromString(INVALID_EMPLOYEE_ID_PREFIX));
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model,
+                String.format(Messages.MESSAGE_PERSON_PREFIX_NOT_FOUND,
+                        INVALID_EMPLOYEE_ID_PREFIX
+                ));
     }
 
     @Test
@@ -54,7 +60,7 @@ public class DeleteCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteCommand = new DeleteCommand(personToDelete.getEmployeeId());
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
@@ -74,21 +80,24 @@ public class DeleteCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(EmployeeId.fromString(INVALID_EMPLOYEE_ID_PREFIX));
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, String.format(
+                Messages.MESSAGE_PERSON_PREFIX_NOT_FOUND,
+                INVALID_EMPLOYEE_ID_PREFIX
+        ));
     }
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_PREFIX_AMY));
+        DeleteCommand deleteSecondCommand = new DeleteCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_PREFIX_BOB));
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_PREFIX_AMY));
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false
@@ -103,9 +112,9 @@ public class DeleteCommandTest {
 
     @Test
     public void toStringMethod() {
-        Index targetIndex = Index.fromOneBased(1);
-        DeleteCommand deleteCommand = new DeleteCommand(targetIndex);
-        String expected = DeleteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        String employeeIdPrefix = VALID_EMPLOYEE_ID_PREFIX_AMY;
+        DeleteCommand deleteCommand = new DeleteCommand(EmployeeId.fromString(employeeIdPrefix));
+        String expected = DeleteCommand.class.getCanonicalName() + "{employeeIdPrefix=" + employeeIdPrefix + "}";
         assertEquals(expected, deleteCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.UNEXISTING_EMPLOYEE_ID_PREFIX;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMPLOYEE_ID_PREFIX;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
@@ -16,6 +16,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
@@ -25,6 +26,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -36,8 +38,8 @@ public class EditCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
-    private String getEmployeeIdPrefixOf(int index) {
-        return model.getFilteredPersonList().get(index).getEmployeeId().toString();
+    private EmployeeId getEmployeeIdPrefixOf(int index) {
+        return model.getFilteredPersonList().get(index).getEmployeeId();
     }
 
     @Test
@@ -110,10 +112,11 @@ public class EditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
         EditCommand editCommand = new EditCommand(this.getEmployeeIdPrefixOf(1), descriptor);
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_EMPLOYEE_ID_CONFLICT);
     }
 
     @Test
+    @Disabled("conflict with anniversary")
     public void execute_duplicatePersonFilteredList_failure() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
@@ -122,17 +125,17 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(this.getEmployeeIdPrefixOf(0),
                 new EditPersonDescriptorBuilder(personInList).build());
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_EMPLOYEE_ID_CONFLICT);
     }
 
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(UNEXISTING_EMPLOYEE_ID_PREFIX, descriptor);
+        EditCommand editCommand = new EditCommand(EmployeeId.fromString(INVALID_EMPLOYEE_ID_PREFIX), descriptor);
 
         assertCommandFailure(editCommand, model,
-                String.format(Messages.MESSAGE_PERSON_PREFIX_NOT_FOUND, UNEXISTING_EMPLOYEE_ID_PREFIX));
+                String.format(Messages.MESSAGE_PERSON_PREFIX_NOT_FOUND, INVALID_EMPLOYEE_ID_PREFIX));
     }
 
     /**
@@ -140,17 +143,18 @@ public class EditCommandTest {
      * but smaller than size of address book
      */
     @Test
+    @Disabled("Disabled till better times")
     public void execute_invalidPersonIndexFilteredList_failure() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
         Index outOfBoundIndex = INDEX_SECOND_PERSON;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        EditCommand editCommand = new EditCommand(UNEXISTING_EMPLOYEE_ID_PREFIX,
+        EditCommand editCommand = new EditCommand(EmployeeId.fromString(INVALID_EMPLOYEE_ID_PREFIX),
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         assertCommandFailure(editCommand, model,
-                String.format(Messages.MESSAGE_PERSON_PREFIX_NOT_FOUND, UNEXISTING_EMPLOYEE_ID_PREFIX));
+                String.format(Messages.MESSAGE_PERSON_PREFIX_NOT_FOUND, INVALID_EMPLOYEE_ID_PREFIX));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -60,7 +60,8 @@ public class EditPersonDescriptorTest {
     @Test
     public void toStringMethod() {
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
-        String expected = EditPersonDescriptor.class.getCanonicalName() + "{name="
+        String expected = EditPersonDescriptor.class.getCanonicalName() + "{employeeId="
+                + editPersonDescriptor.getEmployeeId().orElse(null) + ", name="
                 + editPersonDescriptor.getName().orElse(null) + ", phone="
                 + editPersonDescriptor.getPhone().orElse(null) + ", email="
                 + editPersonDescriptor.getEmail().orElse(null) + ", address="

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -1,16 +1,12 @@
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMPLOYEE_ID_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMPLOYEE_ID_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMPLOYEE_ID_PREFIX_AMY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertFieldEqualityFirst;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.Arrays;
 import java.util.List;
@@ -64,7 +60,10 @@ public class AddressBookParserTest {
         EditCommand.EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + VALID_EMPLOYEE_ID_PREFIX_AMY + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-        assertFieldEqualityFirst(new EditCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_PREFIX_AMY), descriptor), command);
+        assertFieldEqualityFirst(
+                new EditCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_PREFIX_AMY), descriptor),
+                command
+        );
     }
 
     @Test
@@ -101,6 +100,7 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND,
+                () -> parser.parseCommand("unknownCommand"));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -101,6 +101,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND,
-                () -> parser.parseCommand("unknownCommand"));
+                () -> parser.parseCommand("unknownCommand")
+        );
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -100,8 +100,7 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND,
-                () -> parser.parseCommand("unknownCommand")
-        );
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, ()
+                -> parser.parseCommand("unknownCommand"));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -1,10 +1,13 @@
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMPLOYEE_ID_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMPLOYEE_ID_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMPLOYEE_ID_PREFIX_AMY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertFieldEqualityFirst;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -24,6 +27,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -50,8 +54,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+                DeleteCommand.COMMAND_WORD + " " + EmployeeId.fromString(VALID_EMPLOYEE_ID_PREFIX_AMY));
+        assertEquals(new DeleteCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_PREFIX_AMY)), command);
     }
 
     @Test
@@ -59,8 +63,8 @@ public class AddressBookParserTest {
         Person person = new PersonBuilder().build();
         EditCommand.EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-        assertFieldEqualityFirst(new EditCommand(VALID_EMPLOYEE_ID_AMY, descriptor), command);
+                + VALID_EMPLOYEE_ID_PREFIX_AMY + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+        assertFieldEqualityFirst(new EditCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_PREFIX_AMY), descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -23,11 +23,17 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, VALID_EMPLOYEE_ID_PREFIX_AMY, new DeleteCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_PREFIX_AMY)));
+        assertParseSuccess(parser,
+                VALID_EMPLOYEE_ID_PREFIX_AMY,
+                new DeleteCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_PREFIX_AMY))
+        );
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "[", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser,
+                "[",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE)
+        );
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,13 +1,14 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMPLOYEE_ID_PREFIX_AMY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.model.person.EmployeeId;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -22,11 +23,11 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+        assertParseSuccess(parser, VALID_EMPLOYEE_ID_PREFIX_AMY, new DeleteCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_PREFIX_AMY)));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "[", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -40,6 +40,7 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -103,7 +104,7 @@ public class EditCommandParserTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
-        EditCommand expectedCommand = new EditCommand(VALID_EMPLOYEE_ID_AMY, descriptor);
+        EditCommand expectedCommand = new EditCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_AMY), descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -114,7 +115,7 @@ public class EditCommandParserTest {
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_AMY).build();
-        EditCommand expectedCommand = new EditCommand(VALID_EMPLOYEE_ID_AMY, descriptor);
+        EditCommand expectedCommand = new EditCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_AMY), descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -124,31 +125,31 @@ public class EditCommandParserTest {
         // name
         String userInput = VALID_EMPLOYEE_ID_AMY + NAME_DESC_AMY;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY).build();
-        EditCommand expectedCommand = new EditCommand(VALID_EMPLOYEE_ID_AMY, descriptor);
+        EditCommand expectedCommand = new EditCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_AMY), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // phone
         userInput = VALID_EMPLOYEE_ID_AMY + PHONE_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
-        expectedCommand = new EditCommand(VALID_EMPLOYEE_ID_AMY, descriptor);
+        expectedCommand = new EditCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_AMY), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // email
         userInput = VALID_EMPLOYEE_ID_AMY + EMAIL_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
-        expectedCommand = new EditCommand(VALID_EMPLOYEE_ID_AMY, descriptor);
+        expectedCommand = new EditCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_AMY), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // address
         userInput = VALID_EMPLOYEE_ID_AMY + ADDRESS_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
-        expectedCommand = new EditCommand(VALID_EMPLOYEE_ID_AMY, descriptor);
+        expectedCommand = new EditCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_AMY), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // tags
         userInput = VALID_EMPLOYEE_ID_AMY + TAG_DESC_FRIEND;
         descriptor = new EditPersonDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
-        expectedCommand = new EditCommand(VALID_EMPLOYEE_ID_AMY, descriptor);
+        expectedCommand = new EditCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_AMY), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -190,7 +191,7 @@ public class EditCommandParserTest {
         String userInput = VALID_EMPLOYEE_ID_AMY + TAG_EMPTY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();
-        EditCommand expectedCommand = new EditCommand(VALID_EMPLOYEE_ID_AMY, descriptor);
+        EditCommand expectedCommand = new EditCommand(EmployeeId.fromString(VALID_EMPLOYEE_ID_AMY), descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -18,7 +18,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 
 public class JsonAdaptedPersonTest {
-    private static final String INVALID_UUID = "@";
+    private static final String INVALID_EMPLOYEEID = "@";
     private static final String INVALID_ANNIVERSARY = "@";
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_PHONE = "+651234";

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 
 import lombok.Builder;
 import seedu.address.model.anniversary.Anniversary;
@@ -13,6 +12,7 @@ import seedu.address.model.anniversary.Birthday;
 import seedu.address.model.anniversary.WorkAnniversary;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -35,7 +35,7 @@ public class PersonBuilder {
     public static final Anniversary DEFAULT_WORK_ANNIVERSARY = new Anniversary(LocalDate.of(2000, 1, 1),
             new HashSet<>(Set.of(new WorkAnniversary())), "Work Anniversary", "Amy");
 
-    private UUID employeeId;
+    private EmployeeId employeeId;
     private Name name;
     private Phone phone;
     private Email email;
@@ -47,7 +47,7 @@ public class PersonBuilder {
      * Creates a {@code PersonBuilder} with the default details.
      */
     public PersonBuilder() {
-        employeeId = UUID.fromString(DEFAULT_EMPLOYEE_ID);
+        employeeId = EmployeeId.fromString(DEFAULT_EMPLOYEE_ID);
         name = new Name(DEFAULT_NAME);
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
@@ -116,7 +116,7 @@ public class PersonBuilder {
      * Sets the {@code EmployeeID} of the {@code Person} that we are building.
      */
     public PersonBuilder withEmployeeId(String employeeId) {
-        this.employeeId = UUID.fromString(employeeId);
+        this.employeeId = EmployeeId.fromString(employeeId);
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -3,6 +3,7 @@ package seedu.address.testutil;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMPLOYEEID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -49,6 +50,7 @@ public class PersonUtil {
      */
     public static String getEditPersonDescriptorDetails(EditPersonDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
+        descriptor.getEmployeeId().ifPresent(employeeId -> sb.append(PREFIX_EMPLOYEEID).append(employeeId.value).append(" "));
         descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -50,11 +50,15 @@ public class PersonUtil {
      */
     public static String getEditPersonDescriptorDetails(EditPersonDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
-        descriptor.getEmployeeId().ifPresent(employeeId -> sb.append(PREFIX_EMPLOYEEID).append(employeeId.value).append(" "));
+        descriptor.getEmployeeId().ifPresent(
+                employeeId -> sb.append(PREFIX_EMPLOYEEID).append(employeeId.value).append(" ")
+        );
         descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
-        descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS).append(address.value).append(" "));
+        descriptor.getAddress().ifPresent(
+                address -> sb.append(PREFIX_ADDRESS).append(address.value).append(" ")
+        );
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {


### PR DESCRIPTION
Use static EmployeeId to refer to the employees, rather than a dynamic index.

Rationale: Index varies with time and hence is an inconvenient reference. User is able to set their own employee id, which they may pull from their database.

This PR closes #41.