### PR TITLE
Fixes to Find Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -13,8 +13,8 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Employee;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case-insensitive.
+ * Executes a search using the given predicate.
+ * It is assumed the predicate implements all logical rules for keyword matching and field combinations.
  */
 @Getter
 public class FindCommand extends Command {

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -33,9 +33,11 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
+        boolean hasEmptyName = argMultimap.getAllValues(PREFIX_NAME).stream().allMatch(String::isBlank);
+        boolean hasEmptyJp = argMultimap.getAllValues(PREFIX_JOBPOSITION).stream().allMatch(String::isBlank);
+
         // Handles if both fields are present but empty (e.g. n/   jp/   )
-        if (argMultimap.getValue(PREFIX_NAME).map(String::isBlank).orElse(true)
-                && argMultimap.getValue(PREFIX_JOBPOSITION).map(String::isBlank).orElse(true)) {
+        if (hasEmptyName && hasEmptyJp) {
             throw new ParseException(MESSAGE_EMPTY_FIELD_WITH_PREFIX);
         }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -33,12 +33,13 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        // Handles if the user inputs a blank string for both name and job position
+        // Handles if the user inputs a blank string for BOTH name and job position
         if (argMultimap.getValue(PREFIX_NAME).map(String::isBlank).orElse(true)
                 && argMultimap.getValue(PREFIX_JOBPOSITION).map(String::isBlank).orElse(true)) {
             throw new ParseException(MESSAGE_EMPTY_FIELD_WITH_PREFIX);
         }
 
+        //buildPredicate will skip the empty field if one of them is empty
         Predicate<Employee> predicate = PersonSearchPredicateBuilder.buildPredicate(argMultimap);
 
         return new FindCommand(predicate);

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -33,7 +33,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        // Handles if the user inputs a blank string for BOTH name and job position
+        // Handles if both fields are present but empty (e.g. n/   jp/   )
         if (argMultimap.getValue(PREFIX_NAME).map(String::isBlank).orElse(true)
                 && argMultimap.getValue(PREFIX_JOBPOSITION).map(String::isBlank).orElse(true)) {
             throw new ParseException(MESSAGE_EMPTY_FIELD_WITH_PREFIX);

--- a/src/main/java/seedu/address/logic/parser/PersonSearchPredicateBuilder.java
+++ b/src/main/java/seedu/address/logic/parser/PersonSearchPredicateBuilder.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_JOBPOSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -18,6 +19,7 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 public class PersonSearchPredicateBuilder {
 
     private static final Logger logger = LogsCenter.getLogger(PersonSearchPredicateBuilder.class);
+
     /**
      * Builds a {@code Predicate<Employee>} based on the given {@code ArgumentMultimap}.
      * @param argMultimap the argument multimap
@@ -32,19 +34,35 @@ public class PersonSearchPredicateBuilder {
                 .map(jp -> !jp.isBlank()).orElse(false);
 
         if (hasNonEmptyName) {
-            String name = argMultimap.getValue(PREFIX_NAME).get().trim();
-            String[] nameKeywords = name.split("\\s+");
-            Predicate<Employee> namePredicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
-            logger.info("Predicate added: " + namePredicate);
-            combinedPredicate = combinedPredicate.and(namePredicate);
+            List<String> names = argMultimap.getAllValues(PREFIX_NAME);
+            Predicate<Employee> combinedNamePredicate = person -> false;
+            for(String name : names) {
+                if (name.isBlank()) {
+                    continue;
+                }
+                name = name.trim();
+                String[] nameKeywords = name.split("\\s+");
+                Predicate<Employee> namePredicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
+                logger.info("Predicate added: " + namePredicate);
+                combinedNamePredicate = combinedNamePredicate.or(namePredicate);
+            }
+            combinedPredicate = combinedPredicate.and(combinedNamePredicate);
         }
 
         if (hasNonEmptyJob) {
-            String job = argMultimap.getValue(PREFIX_JOBPOSITION).get().trim();
-            String[] jobKeywords = job.split("\\s+");
-            Predicate<Employee> jpPredicate = new JobPositionContainsKeywordsPredicate(Arrays.asList(jobKeywords));
-            logger.info("Predicate added: " + jpPredicate);
-            combinedPredicate = combinedPredicate.and(jpPredicate);
+            List<String> jobs = argMultimap.getAllValues(PREFIX_JOBPOSITION);
+            Predicate<Employee> combinedJpPredicate = person -> false;
+            for(String job : jobs) {
+                if (job.isBlank()) {
+                    continue;
+                }
+                job = job.trim();
+                String[] jobKeywords = job.split("\\s+");
+                Predicate<Employee> jpPredicate = new JobPositionContainsKeywordsPredicate(Arrays.asList(jobKeywords));
+                logger.info("Predicate added: " + jpPredicate);
+                combinedJpPredicate = combinedJpPredicate.or(jpPredicate);
+            }
+            combinedPredicate = combinedPredicate.and(combinedJpPredicate);
         }
 
         return combinedPredicate;

--- a/src/main/java/seedu/address/logic/parser/PersonSearchPredicateBuilder.java
+++ b/src/main/java/seedu/address/logic/parser/PersonSearchPredicateBuilder.java
@@ -26,10 +26,12 @@ public class PersonSearchPredicateBuilder {
     public static Predicate<Employee> buildPredicate(ArgumentMultimap argMultimap) {
         Predicate<Employee> combinedPredicate = person -> true;
 
-        boolean hasName = argMultimap.getValue(PREFIX_NAME).isPresent();
-        boolean hasJob = argMultimap.getValue(PREFIX_JOBPOSITION).isPresent();
+        boolean hasNonEmptyName = argMultimap.getValue(PREFIX_NAME)
+                .map(name -> !name.isBlank()).orElse(false);
+        boolean hasNonEmptyJob = argMultimap.getValue(PREFIX_JOBPOSITION)
+                .map(jp -> !jp.isBlank()).orElse(false);
 
-        if (hasName) {
+        if (hasNonEmptyName) {
             String name = argMultimap.getValue(PREFIX_NAME).get().trim();
             String[] nameKeywords = name.split("\\s+");
             Predicate<Employee> namePredicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
@@ -37,7 +39,7 @@ public class PersonSearchPredicateBuilder {
             combinedPredicate = combinedPredicate.and(namePredicate);
         }
 
-        if (hasJob) {
+        if (hasNonEmptyJob) {
             String job = argMultimap.getValue(PREFIX_JOBPOSITION).get().trim();
             String[] jobKeywords = job.split("\\s+");
             Predicate<Employee> jpPredicate = new JobPositionContainsKeywordsPredicate(Arrays.asList(jobKeywords));

--- a/src/main/java/seedu/address/logic/parser/anniversary/ShowAnniversaryCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/anniversary/ShowAnniversaryCommandParser.java
@@ -7,6 +7,7 @@ import seedu.address.logic.commands.anniversary.ShowAnniversaryCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.EmployeeId;
 
@@ -30,7 +31,7 @@ public class ShowAnniversaryCommandParser implements Parser<ShowAnniversaryComma
             );
         }
 
-        String employeeId = argMultimap.getValue(PREFIX_EMPLOYEEID).get();
-        return new ShowAnniversaryCommand(EmployeeId.fromString(employeeId));
+        EmployeeId employeeId = ParserUtil.parseEmployeeId(argMultimap.getValue(PREFIX_EMPLOYEEID).get());
+        return new ShowAnniversaryCommand(employeeId);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -183,4 +183,11 @@ public class FindCommandParserTest {
         assertEquals(FindCommand.class, command.getClass());
     }
 
+    // Should pass as it will skip the empty field
+    @Test
+    public void parse_multipleBlankField_stillParses() throws Exception {
+        FindCommand command = parser.parse(" n/   n/jack jp/   \n jp/engineer ");
+        assertEquals(FindCommand.class, command.getClass());
+    }
+
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -169,7 +169,8 @@ public class FindCommandParserTest {
         assertParseFailure(parser, " n/   jp/   ",
                 seedu.address.logic.Messages.MESSAGE_EMPTY_FIELD_WITH_PREFIX);
     }
-    
+
+    // Should fail as there should be no preamble
     @Test
     public void parse_preamble_throwsParseException() {
         assertParseFailure(parser, " 2134rt n/jack jp/engineer",

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -163,4 +163,24 @@ public class FindCommandParserTest {
 
         assertEquals(List.of(matching), model.getFilteredEmployeeList());
     }
+
+    @Test
+    public void parse_emptyFieldsWithPrefixes_throwsParseException() {
+        assertParseFailure(parser, " n/   jp/   ",
+                seedu.address.logic.Messages.MESSAGE_EMPTY_FIELD_WITH_PREFIX);
+    }
+    
+    @Test
+    public void parse_preamble_throwsParseException() {
+        assertParseFailure(parser, " 2134rt n/jack jp/engineer",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    // Should pass as it will skip the empty field
+    @Test
+    public void parse_oneBlankField_stillParses() throws Exception {
+        FindCommand command = parser.parse(" n/   jp/engineer ");
+        assertEquals(FindCommand.class, command.getClass());
+    }
+
 }

--- a/src/test/java/seedu/address/logic/parser/ShowAnniversaryCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ShowAnniversaryCommandParserTest.java
@@ -35,11 +35,17 @@ public class ShowAnniversaryCommandParserTest {
                 thrown.getMessage());
     }
 
-    //Solve in another branch
-    @Disabled
     @Test
     public void parse_emptyEidValue_throwsParseException() {
         String userInput = " " + PREFIX_EMPLOYEEID + " ";
+        ParseException thrown = assertThrows(ParseException.class, () -> parser.parse(userInput));
+        assertEquals(String.format(EmployeeId.MESSAGE_CONSTRAINTS),
+                thrown.getMessage());
+    }
+
+    @Test
+    public void parse_nonEmptyPreamble_throwsParseException() {
+        String userInput = " lwjfbopwou " + PREFIX_EMPLOYEEID + " " + employeeId;
         ParseException thrown = assertThrows(ParseException.class, () -> parser.parse(userInput));
         assertEquals(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowAnniversaryCommand.MESSAGE_USAGE),
                 thrown.getMessage());

--- a/src/test/java/seedu/address/logic/parser/ShowAnniversaryCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ShowAnniversaryCommandParserTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMPLOYEEID;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.anniversary.ShowAnniversaryCommand;


### PR DESCRIPTION
This PR closes #140 (empty 1 field while other is not)
- Solve this by making it so that if the one field is empty but the other is not, the empty field will be skipped.

Closes #139 (Multiple inputs)
- Solve this by making it so that it goes through all prefixes, then ORs them so that eg. `find n/Alice n/Bob` == `find n/Alice Bob`

Closes #141 (Clarification)
- Accepted the new suggestion

Also closes #78 as a byproduct 